### PR TITLE
Fix annotations according to more precise psalm checks

### DIFF
--- a/src/Mess.php
+++ b/src/Mess.php
@@ -44,7 +44,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int
      */
@@ -59,7 +59,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool
      */
@@ -74,7 +74,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string
      */
@@ -89,7 +89,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>
      *
      * @return array
@@ -105,7 +105,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>
      *
      * @return array
@@ -121,7 +121,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,int>
      *
      * @return array
@@ -137,7 +137,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,bool>
      *
      * @return array
@@ -156,7 +156,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,string>
      *
      * @return array
@@ -175,7 +175,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int
      */
@@ -192,7 +192,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool
      */
@@ -206,7 +206,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string
      */
@@ -220,7 +220,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>
      *
      * @return array
@@ -238,7 +238,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>
      *
      * @return array
@@ -256,7 +256,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,int>
      *
      * @return array
@@ -274,7 +274,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,bool>
      *
      * @return array
@@ -292,7 +292,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,string>
      *
      * @return array
@@ -310,7 +310,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int|null
      */
@@ -324,7 +324,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool|null
      */
@@ -338,7 +338,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string|null
      */
@@ -352,7 +352,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>|null
      *
      * @return array|null
@@ -367,7 +367,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>|null
      *
      * @return array|null
@@ -382,7 +382,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,int>|null
      *
      * @return array|null
@@ -397,7 +397,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,bool>|null
      *
      * @return array|null
@@ -412,7 +412,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,string>|null
      *
      * @return array|null
@@ -427,7 +427,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int|null
      */
@@ -441,7 +441,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool|null
      */
@@ -455,7 +455,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string|null
      */
@@ -497,7 +497,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,int>|null
      *
      * @return array|null
@@ -512,7 +512,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,bool>|null
      *
      * @return array|null
@@ -527,7 +527,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,string>|null
      *
      * @return array|null
@@ -542,7 +542,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return mixed
      */
@@ -578,7 +578,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,mixed>
      *
      * @return array
@@ -594,7 +594,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return mixed
      */
@@ -628,7 +628,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string,mixed>|null
      *
      * @return array|null
@@ -643,7 +643,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @param string|int $offset
      * @return MessInterface
@@ -668,7 +668,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @param string|int $offset
      * @return bool
@@ -687,7 +687,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @param mixed $offset
      * @param mixed $value
@@ -698,7 +698,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @param mixed $offset
      */
@@ -708,7 +708,7 @@ class Mess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-external-mutation-free
      * @psalm-param list<string|int> $keySequence
      *
      * @param array $keySequence

--- a/src/MissingMess.php
+++ b/src/MissingMess.php
@@ -33,7 +33,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int
      */
@@ -43,7 +43,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool
      */
@@ -53,7 +53,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string
      */
@@ -63,7 +63,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>
      *
      * @return array
@@ -74,7 +74,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>
      *
      * @return array
@@ -85,7 +85,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, int>
      *
      * @return array
@@ -96,7 +96,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, bool>
      *
      * @return array
@@ -107,7 +107,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, string>
      *
      * @return array
@@ -118,7 +118,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int
      */
@@ -128,7 +128,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool
      */
@@ -138,7 +138,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string
      */
@@ -148,7 +148,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>
      *
      * @return array
@@ -159,7 +159,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>
      *
      * @return array
@@ -170,7 +170,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, int>
      *
      * @return array
@@ -181,7 +181,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, bool>
      *
      * @return array
@@ -192,7 +192,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, string>
      *
      * @return array
@@ -203,7 +203,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int|null
      */
@@ -213,7 +213,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool|null
      */
@@ -223,7 +223,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string|null
      */
@@ -233,7 +233,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>
      *
      * @return array|null
@@ -244,7 +244,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>
      *
      * @return array|null
@@ -255,7 +255,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, int>|null
      *
      * @return array|null
@@ -266,7 +266,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, bool>|null
      *
      * @return array|null
@@ -277,7 +277,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, string>|null
      *
      * @return array|null
@@ -288,7 +288,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return int|null
      */
@@ -298,7 +298,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return bool|null
      */
@@ -308,7 +308,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return string|null
      */
@@ -318,7 +318,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<int>|null
      *
      * @return array|null
@@ -329,7 +329,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return list<string>|null
      *
      * @return array|null
@@ -340,7 +340,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, int>|null
      *
      * @return array|null
@@ -351,7 +351,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, bool>|null
      *
      * @return array|null
@@ -362,7 +362,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, string>|null
      *
      * @return array|null
@@ -373,7 +373,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return mixed
      */
@@ -383,7 +383,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return object
      */
@@ -393,7 +393,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return array
      */
@@ -403,7 +403,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, mixed>
      *
      * @return array
@@ -414,7 +414,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return mixed
      */
@@ -424,7 +424,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return object|null
      */
@@ -434,7 +434,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @return array|null
      */
@@ -444,7 +444,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @psalm-return array<string, mixed>|null
      *
      * @return array|null
@@ -455,7 +455,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @param mixed $offset
      *
      * @return bool
@@ -466,7 +466,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @param int|string $offset
      *
      * @return self
@@ -487,7 +487,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @param mixed $offset
      * @param mixed $value
@@ -498,7 +498,7 @@ final class MissingMess implements MessInterface
     }
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      *
      * @param mixed $offset
      */

--- a/src/functions.php
+++ b/src/functions.php
@@ -118,7 +118,6 @@ namespace Zakirullin\Mess
     }
 
     /**
-     * @psalm-pure
      * @psalm-return array<string,mixed>|null
      *
      * @param mixed    $value
@@ -130,7 +129,7 @@ namespace Zakirullin\Mess
         if (!isArrayOfStringToMixed($value)) {
             return null;
         }
-
+        /** @var array<string, mixed> $value */
         $arrayOfStringToCasted = [];
         /**
          * @var string $key

--- a/src/functions.php
+++ b/src/functions.php
@@ -118,10 +118,11 @@ namespace Zakirullin\Mess
     }
 
     /**
+     * @psalm-pure
      * @psalm-return array<string,mixed>|null
      *
      * @param mixed    $value
-     * @param callable $caster
+     * @param pure-callable(mixed) $caster
      * @return array|null
      */
     function toArrayOfStringToType($value, callable $caster): ?array
@@ -181,7 +182,7 @@ namespace Zakirullin\Mess
      * @psalm-pure
      *
      * @param mixed    $value
-     * @param callable $typeChecker
+     * @param pure-callable(mixed): bool $typeChecker
      * @return bool
      */
     function isListOfType($value, callable $typeChecker): bool
@@ -232,7 +233,7 @@ namespace Zakirullin\Mess
      * @psalm-pure
      *
      * @param mixed    $value
-     * @param callable $isType
+     * @param pure-callable(mixed): bool $isType
      * @return bool
      */
     function isArrayOfStringToType($value, callable $isType)


### PR DESCRIPTION
Two groups of annotations fixed
 - for getters - `pure` replaced  with `mutation-free`,
 - for conversion functions - add `pure-callable` annotations
related to #12 