### PR TITLE
Little fixes to make it compatible with 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require-dev": {
     "infection/infection": "^0.15|^0.20",
     "phpunit/phpunit": "^8.0",
-    "vimeo/psalm": "4.3.1"
+    "vimeo/psalm": "4.16.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/MessInterface.php
+++ b/src/MessInterface.php
@@ -331,5 +331,6 @@ interface MessInterface extends ArrayAccess
      * @param string|int $offset
      * @return MessInterface
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset);
 }

--- a/src/MissingMess.php
+++ b/src/MissingMess.php
@@ -523,6 +523,7 @@ final class MissingMess implements MessInterface
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -238,11 +238,7 @@ namespace Zakirullin\Mess
             return false;
         }
 
-        /**
-         * @var array $value
-         * @var mixed $val
-         */
-        foreach ($value as $key => $val) {
+        foreach (array_keys($value) as $key) {
             if (!is_string($key)) {
                 return false;
             }


### PR DESCRIPTION
- add `#[\ReturnTypeWillChange]` for `MessInterface::getOffset`
- update `psalm` to handle `ReturnTypeWillChange`
- fix `isArrayOfStringToMixed` function - get rid of unused var & dockblock