### PR TITLE
add github actions build with php 7.2 <-> 8.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
       group: run--${{ github.ref }}
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']
         
     runs-on: ubuntu-latest
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
       group: run--${{ github.ref }}
     strategy:
       matrix:
-        php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
         
     runs-on: ubuntu-latest
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   build:
-    concurrency:
-      group: run--${{ github.ref }}
     strategy:
       matrix:
         php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,46 @@
+name: GitHub Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    concurrency:
+      group: run--${{ github.ref }}
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']
+        
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: setup PHP.
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+
+    - name: php version check
+      run: php -v
+
+    - name: Validate composer.json 
+      run: composer validate --strict
+        
+    - name: run composer (install dependencies)
+      run: composer install --prefer-dist --no-progress
+
+    - name: run psalm (static analysis)
+      run: vendor/bin/psalm 
+   
+    - name: run unit tests
+      run: composer test
+    
+

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,12 @@
     "php": "^7.2|^8.0"
   },
   "require-dev": {
-    "infection/infection": "^0.15|^0.20",
-    "phpunit/phpunit": "^8.0",
-    "vimeo/psalm": "4.16.1"
+    "composer/xdebug-handler": "^1.4|2.0",
+    "infection/infection": "^0.15|^0.20|^0.27",
+    "phpunit/phpunit": "^8.0|^9.0",
+    "symfony/string": "^5.4.43",
+    "sanmai/pipeline": "5.2.1",
+    "vimeo/psalm": "4.16.1|5.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,10 @@
     }
   ],
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "infection/extension-installer": true
+    }
   },
   "require": {
     "php": "^7.2|^8.0"
@@ -42,7 +45,7 @@
   },
   "scripts": {
     "test": [
-      "phpunit --stderr --coverage-text"
+      "@php vendor/bin/phpunit --stderr --coverage-text"
     ],
     "coverage": "phpunit --coverage-html=coverage"
   },

--- a/src/MessInterface.php
+++ b/src/MessInterface.php
@@ -5,6 +5,9 @@ namespace Zakirullin\Mess;
 
 use ArrayAccess;
 
+/**
+ * @psalm-suppress MissingTemplateParam
+ */
 interface MessInterface extends ArrayAccess
 {
     /**


### PR DESCRIPTION
 * adds build within github actions, with different PHP versions (7.2 -> 8.3) 
 * change require-dev composer package versions a little to allow it to be installed on php7.2 <-> 8.3 without psalm thinking there are syntax errors in e.g. symfony/string when building on php 7.2
