### PR TITLE
Psalm and php84

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,7 +36,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: run psalm (static analysis)
-      run: vendor/bin/psalm 
+      run: vendor/bin/psalm.phar
    
     - name: run unit tests
       run: composer test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
 
     - uses: actions/checkout@v4
 
-    - name: setup PHP.
+    - name: setup PHP ${{ matrix.php-versions }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
@@ -38,7 +38,6 @@ jobs:
     - name: run psalm (static analysis)
       run: vendor/bin/psalm.phar
    
-    - name: run unit tests
+    - name: run unit tests ( ${{ matrix.php-versions }} )
       run: composer test
     
-

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         
     runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "composer/xdebug-handler": "^1.4|2.0",
-    "infection/infection": "^0.15|^0.20|^0.27",
+    "infection/infection": "*",
     "phpunit/phpunit": "^8.0|^9.0",
     "symfony/string": "^5.4.43",
     "sanmai/pipeline": "5.2.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "phpunit/phpunit": "^8.0|^9.0",
     "symfony/string": "^5.4.43",
     "sanmai/pipeline": "5.2.1",
-    "vimeo/psalm": "4.16.1|5.*"
+    "psalm/phar": "*"
   },
   "autoload": {
     "psr-4": {

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -11,5 +11,11 @@
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>
+
     </projectFiles>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="info"/>
+        <UnusedClass errorLevel="info"/>
+        <PossiblyUnusedMethod errorLevel="info"/>
+    </issueHandlers>
 </psalm>

--- a/src/Mess.php
+++ b/src/Mess.php
@@ -768,7 +768,7 @@ class Mess implements MessInterface
      * @param string|int $offset
      * @return MessInterface
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): MessInterface
     {
         /**
          * @psalm-suppress DocblockTypeContradiction

--- a/src/MessInterface.php
+++ b/src/MessInterface.php
@@ -334,6 +334,5 @@ interface MessInterface extends ArrayAccess
      * @param string|int $offset
      * @return MessInterface
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset);
+    public function offsetGet($offset): MessInterface;
 }

--- a/src/MissingMess.php
+++ b/src/MissingMess.php
@@ -520,11 +520,8 @@ final class MissingMess implements MessInterface
 
     /**
      * @param int|string $offset
-     *
-     * @return self
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): MessInterface
     {
         /**
          * @psalm-suppress DocblockTypeContradiction

--- a/src/functions.php
+++ b/src/functions.php
@@ -124,9 +124,13 @@ namespace Zakirullin\Mess
 
         $listOfCasted = [];
         /**
-         * @psalm-suppress all
+         * @psalm-suppress ImpureMethodCall
+         * @psalm-suppress MixedAssignment
          */
         foreach ($value as $val) {
+            /**
+             * @psalm-suppress ImpureFunctionCall
+             */
             $castedValue = $caster($val);
             if ($castedValue === null) {
                 return null;


### PR DESCRIPTION
 * Allow psalm to update (by moving to use the phar release, which drags in fewer libraries/dependencies)
 * add build support for PHP 8.4
 * change offsetGet() to return a MessInterface rather than @ return MessInterface or self etc.
