### PR TITLE
fix build issue from phar/psalm

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ['7.2', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.2']
         
     runs-on: ubuntu-24.04
 
@@ -36,7 +36,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: run psalm (static analysis)
-      run: vendor/bin/psalm.phar
+      run: vendor/bin/psalm
    
     - name: run unit tests ( ${{ matrix.php-versions }} )
       run: composer test

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "phpunit/phpunit": "^8.0|^9.0",
     "symfony/string": "^5.4.43",
     "sanmai/pipeline": "5.2.1",
-    "psalm/phar": "*"
+    "vimeo/psalm": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
annoyingly psalm/phar does not work on versions of PHP below 8.1.31 or something, so move back to vimeo/psalm.

Error seen is like : "Box Requirements Checker .... Your system is not ready to run the application ... requires PHP ~8.1.31 +"